### PR TITLE
Feat: Unittest for FileFormat Validation

### DIFF
--- a/EksamensProjekt/Services/DragAndDropService.cs
+++ b/EksamensProjekt/Services/DragAndDropService.cs
@@ -20,24 +20,32 @@ namespace EksamensProjekt.Services
             if (e.Data.GetDataPresent(DataFormats.FileDrop))
             {
                 var files = (string[])e.Data.GetData(DataFormats.FileDrop);
-                foreach (var file in files)
-                {
-                    var extension = Path.GetExtension(file);
-                    if (extension.Equals(".XLSX", StringComparison.OrdinalIgnoreCase) ||
-                        extension.Equals(".XLS", StringComparison.OrdinalIgnoreCase) ||
-                        extension.Equals(".CSV", StringComparison.OrdinalIgnoreCase))
-                    {
-                        FileDropped?.Invoke(file); // Call ViewModel when file is dropped
-                        break;
-                    }
-                    else
-                    {
-                        MessageBox.Show("Kun filformater (.xlsx, .xls, .csv) kan bruges.");
-                    }
-                }
+                ValidateFileFormat(files);
             }
             e.Handled = true;
         }
+
+
+        public void ValidateFileFormat(string[] files)
+        {
+            foreach (var file in files)
+            {
+                var extension = Path.GetExtension(file);
+                if (extension.Equals(".XLSX", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".XLS", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".CSV", StringComparison.OrdinalIgnoreCase))
+                {
+                    FileDropped?.Invoke(file); // Call ViewModel when file is dropped
+                    break;
+                }
+                else
+                {
+                    throw new FormatException($"Unsupported file format: {extension}");
+                }
+            }
+        }
+
+
 
     }
 }

--- a/EksamensProjekt/ViewModels/TenancyUploadViewModel.cs
+++ b/EksamensProjekt/ViewModels/TenancyUploadViewModel.cs
@@ -52,7 +52,6 @@ namespace EksamensProjekt.ViewModels
             // Initialize commands
             ApproveAllMatchesCommand = new RelayCommand(ExecuteApproveAllMatches, CanExecuteApproveAllAddresses);
             GoToTenancyCommand = new RelayCommand(ExecuteGoToTenancyCommand);
-
             DeleteTenancyCommand = new RelayCommand(DeleteAddressCommand, CanExecuteDeleteAddress);
 
         }
@@ -84,7 +83,6 @@ namespace EksamensProjekt.ViewModels
             get => _filepath;
             set
             {
-                // Set the new value
                 _filepath = value;
 
                 // Only call LoadAndMatchImportedAddresses if the Filepath is not null or empty
@@ -95,8 +93,7 @@ namespace EksamensProjekt.ViewModels
                 }
                 else
                 {
-                    // Optionally, you can handle the null case here if needed
-                    // For example, clear any imported addresses
+                    // clear any imported addresses
                     ImportedAddresses.Clear();
                 }
             }

--- a/EksamensProjekt/Views/TenancyUploadView.xaml.cs
+++ b/EksamensProjekt/Views/TenancyUploadView.xaml.cs
@@ -25,7 +25,14 @@ public partial class TenancyUploadView : Window
     {
         if (DataContext is TenancyUploadViewModel viewModel)
         {
-            viewModel.DragAndDropService.HandleDrop(sender, e);
+            try
+            {
+                viewModel.DragAndDropService.HandleDrop(sender, e);
+            }
+            catch (FormatException ex)
+            {
+                MessageBox.Show("Kun filformater (.xlsx, .xls, .csv) kan bruges.");
+            }
         }
     }
 }

--- a/EksamensProjektTest/DragAndDropTest.cs
+++ b/EksamensProjektTest/DragAndDropTest.cs
@@ -1,0 +1,39 @@
+﻿using EksamensProjekt.Services;
+
+[TestClass]
+public class DragAndDropServiceTests
+{
+    private DragAndDropService dragAndDropService;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        dragAndDropService = new DragAndDropService();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(FormatException))]
+    [DeploymentItem("Resources/FileWithInvalidFormat.ods", "Resources")]
+    public void ValidateFileFormat_InvalidFileFormat_ThrowsFormatException()
+    {
+        // Arrange: Path to the invalid file
+        var filePath = Path.Combine("Resources", "FileWithInvalidFormat.ods");
+        var files = new string[] { filePath }; // Wrap filePath into an array
+
+        // Act: Call the validation logic
+        dragAndDropService.ValidateFileFormat(files);
+
+        // Assert is handled by ExpectedException
+    }
+
+    [TestMethod]
+    public void ValidateFileFormat_ValidFileFormat_DoesNotThrow()
+    {
+        // Arrange: Path to a valid file with .xlsx
+        var validFilePath = Path.Combine("Resources", "ValidFile.xlsx");
+        var files = new string[] { validFilePath }; // Wrap filePath into an array
+
+        // Act & Assert: No exception thrown
+        dragAndDropService.ValidateFileFormat(files);
+    }
+}


### PR DESCRIPTION
Fix: refactored DragAndDrop fileextension check to be a helper method.
Fix: Removed message box from ServiceLayer. Throw exception instead.
Fix: Handle the exception in View and show message box on FormatException